### PR TITLE
Derive blob key extension from Content-Type (so extension-based CDNs serve the right Content-Type)

### DIFF
--- a/src/blobstore/extension.test.ts
+++ b/src/blobstore/extension.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for content-type → extension mapping used when generating blob keys.
+ */
+import { describe, test, expect } from "vitest";
+import { extensionForContentType } from "./extension.js";
+
+describe("extensionForContentType", () => {
+  test("maps common media types", () => {
+    expect(extensionForContentType("video/mp4")).toBe(".mp4");
+    expect(extensionForContentType("video/quicktime")).toBe(".mov");
+    expect(extensionForContentType("image/jpeg")).toBe(".jpg");
+    expect(extensionForContentType("image/png")).toBe(".png");
+    expect(extensionForContentType("audio/mpeg")).toBe(".mp3");
+    expect(extensionForContentType("application/pdf")).toBe(".pdf");
+  });
+
+  test("ignores content-type parameters", () => {
+    expect(extensionForContentType("image/jpeg; charset=binary")).toBe(".jpg");
+    expect(extensionForContentType("video/mp4;codecs=avc1")).toBe(".mp4");
+  });
+
+  test("is case-insensitive", () => {
+    expect(extensionForContentType("VIDEO/MP4")).toBe(".mp4");
+    expect(extensionForContentType("Image/PNG")).toBe(".png");
+  });
+
+  test("returns empty string for unknown or opaque types", () => {
+    expect(extensionForContentType("application/octet-stream")).toBe("");
+    expect(extensionForContentType("application/x-made-up")).toBe("");
+    expect(extensionForContentType("")).toBe("");
+  });
+
+  test("never returns undefined", () => {
+    expect(typeof extensionForContentType("whatever")).toBe("string");
+  });
+});

--- a/src/blobstore/extension.ts
+++ b/src/blobstore/extension.ts
@@ -1,0 +1,70 @@
+/**
+ * Maps common Content-Types to a canonical file extension (with leading dot).
+ *
+ * Blob keys are opaque UUIDs with no extension. Some object stores and CDNs —
+ * notably Bunny.net Edge Storage — derive the `Content-Type` they *serve* from
+ * the key's file extension rather than the type set at upload time. Without an
+ * extension those stores serve every blob as `application/octet-stream`, which
+ * breaks strict media clients: byte-range video/audio players (AVPlayer,
+ * ExoPlayer) refuse to play a stream typed `application/octet-stream` even
+ * though the bytes are correct. Appending the extension to the blob key makes
+ * such stores serve the right `Content-Type`, and is harmless for stores that
+ * honor the uploaded `Content-Type` directly (S3, R2, GCS).
+ */
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  // Images
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/avif": ".avif",
+  "image/heic": ".heic",
+  "image/heif": ".heif",
+  "image/svg+xml": ".svg",
+  "image/bmp": ".bmp",
+  "image/tiff": ".tiff",
+  "image/x-icon": ".ico",
+  // Video
+  "video/mp4": ".mp4",
+  "video/quicktime": ".mov",
+  "video/webm": ".webm",
+  "video/x-matroska": ".mkv",
+  "video/mpeg": ".mpeg",
+  "video/3gpp": ".3gp",
+  "video/x-msvideo": ".avi",
+  // Audio
+  "audio/mpeg": ".mp3",
+  "audio/mp4": ".m4a",
+  "audio/aac": ".aac",
+  "audio/ogg": ".ogg",
+  "audio/opus": ".opus",
+  "audio/wav": ".wav",
+  "audio/webm": ".weba",
+  "audio/flac": ".flac",
+  // Documents & data
+  "application/pdf": ".pdf",
+  "application/json": ".json",
+  "application/zip": ".zip",
+  "application/gzip": ".gz",
+  "text/plain": ".txt",
+  "text/csv": ".csv",
+  "text/html": ".html",
+  "text/markdown": ".md",
+  "text/css": ".css",
+  "text/javascript": ".js",
+};
+
+/**
+ * Returns the canonical file extension (including the leading dot) for a
+ * Content-Type, or an empty string when the type is unknown. Content-Type
+ * parameters (e.g. `; charset=utf-8`) and casing are ignored.
+ *
+ * @example
+ * extensionForContentType("video/mp4") // ".mp4"
+ * extensionForContentType("image/jpeg; charset=binary") // ".jpg"
+ * extensionForContentType("application/octet-stream") // ""
+ */
+export function extensionForContentType(contentType: string): string {
+  const normalized = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  return EXTENSION_BY_CONTENT_TYPE[normalized] ?? "";
+}

--- a/src/blobstore/index.ts
+++ b/src/blobstore/index.ts
@@ -14,6 +14,7 @@ export type {
 
 export { createBunnyBlobStore } from "./bunny.js";
 export { createTestBlobStore } from "./test.js";
+export { extensionForContentType } from "./extension.js";
 
 import type { BlobStore, StorageConfig } from "./types.js";
 import { createBunnyBlobStore } from "./bunny.js";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -46,6 +46,7 @@ import type {
 } from "./types.js";
 import type { FileMetadata } from "../component/types.js";
 import { createBlobStore } from "../blobstore/index.js";
+import { extensionForContentType } from "../blobstore/extension.js";
 
 // Re-export types for consumers
 export type { Config, FileMetadata, Op, Dest } from "../component/types.js";
@@ -280,8 +281,9 @@ export class ConvexFS {
   ): Promise<string> {
     const storage = this.options.storage;
 
-    // Generate blobId locally
-    const blobId = crypto.randomUUID();
+    // Generate blobId locally. The extension lets extension-based stores/CDNs
+    // (e.g. Bunny.net) serve the correct Content-Type on download.
+    const blobId = crypto.randomUUID() + extensionForContentType(contentType);
 
     // Upload directly to blob store (data plane in caller's context)
     const store = createBlobStore(storage);
@@ -705,8 +707,9 @@ export function registerRoutes(
         ? parseInt(contentLengthHeader, 10)
         : 0;
 
-      // Generate blobId locally
-      const blobId = crypto.randomUUID();
+      // Generate blobId locally. The extension lets extension-based stores/CDNs
+      // (e.g. Bunny.net) serve the correct Content-Type on download.
+      const blobId = crypto.randomUUID() + extensionForContentType(contentType);
 
       try {
         // Stream the request body directly to storage (data plane)


### PR DESCRIPTION
## Problem

Blob keys are opaque UUIDs with **no file extension**. Some object stores and CDNs — notably **Bunny.net Edge Storage** — derive the `Content-Type` they *serve* from the key's file extension, **not** the `Content-Type` set at upload time.

The result: every blob is served as `application/octet-stream`. Images survive this (clients like `expo-image`/browsers sniff the bytes), but **strict byte-range media players do not** — iOS `AVPlayer` and Android `ExoPlayer` refuse to play a video/audio stream typed `application/octet-stream`, even though the stored bytes are a perfectly valid MP4. So video/audio stored via ConvexFS on Bunny is unplayable.

Repro (Bunny): upload an `.mp4`, then `curl -I` the download URL → `Content-Type: application/octet-stream`. The same object stored under a `.mp4` key → `Content-Type: video/mp4`.

## Fix

Append an extension derived from the `Content-Type` to newly generated blob keys, at both mint sites (`writeBlob` and the `/upload` proxy route):

```ts
const blobId = crypto.randomUUID() + extensionForContentType(contentType);
```

- Adds `extensionForContentType(contentType)` (exported from `blobstore`), a self-contained map of common image/video/audio/document types → extension. Unknown types return `""` (key stays extensionless, i.e. current behavior).
- **Backward compatible**: only newly-minted keys change; existing extensionless blobs keep resolving (`parseDownloadUrl`/`buildDownloadUrl` treat the blobId as an opaque last path segment, dot included).
- **Harmless for stores that honor the uploaded `Content-Type`** (S3/R2/GCS) — the extension is just cosmetic there.

## Tests

`npm test` green (101 tests). Added unit tests for `extensionForContentType` (mapping, content-type params, casing, unknown types).

## Note

I made this on by default since it's a correctness fix that's backward compatible, but I'm happy to gate it behind a storage-config flag (e.g. `appendExtension?: boolean` or a custom `extensionForContentType` override) if you'd prefer it opt-in.
